### PR TITLE
fix: resolve all Ruff lint errors (E702, E701, E741, E401, F401, F601)

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -867,26 +867,36 @@ def update_tenancy_profile(
     fields: list = []
     values: list = []
     if name is not None:
-        fields.append("name = ?"); values.append(name.strip())
+        fields.append("name = ?")
+        values.append(name.strip())
     if auth_method is not None:
-        fields.append("auth_method = ?"); values.append(auth_method.upper())
+        fields.append("auth_method = ?")
+        values.append(auth_method.upper())
     if region is not None:
-        fields.append("region = ?"); values.append(region)
+        fields.append("region = ?")
+        values.append(region)
     if tenancy_name is not None:
-        fields.append("tenancy_name = ?"); values.append(tenancy_name)
+        fields.append("tenancy_name = ?")
+        values.append(tenancy_name)
     if is_public is not None:
-        fields.append("is_public = ?"); values.append(1 if is_public else 0)
+        fields.append("is_public = ?")
+        values.append(1 if is_public else 0)
     if is_active is not None:
-        fields.append("is_active = ?"); values.append(1 if is_active else 0)
+        fields.append("is_active = ?")
+        values.append(1 if is_active else 0)
     if visibility is not None:
         valid_vis = {"admin_only", "all_users", "by_group", "by_user"}
-        fields.append("visibility = ?"); values.append(visibility if visibility in valid_vis else "by_group")
+        fields.append("visibility = ?")
+        values.append(visibility if visibility in valid_vis else "by_group")
     if tenancy_ocid is not None:
-        fields.append("tenancy_ocid = ?"); values.append(tenancy_ocid)
+        fields.append("tenancy_ocid = ?")
+        values.append(tenancy_ocid)
     if user_ocid is not None:
-        fields.append("user_ocid = ?"); values.append(user_ocid)
+        fields.append("user_ocid = ?")
+        values.append(user_ocid)
     if fingerprint is not None:
-        fields.append("fingerprint = ?"); values.append(fingerprint)
+        fields.append("fingerprint = ?")
+        values.append(fingerprint)
     if private_key_pem is not None:
         fields.append("private_key_encrypted = ?")
         values.append(encrypt_value(private_key_pem))

--- a/backend/doc_generator.py
+++ b/backend/doc_generator.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple
 
-import docx
 from docx import Document
 from docx.enum.style import WD_STYLE_TYPE
 from docx.enum.text import WD_ALIGN_PARAGRAPH
@@ -257,7 +256,6 @@ DOC_STRINGS = {
         "doc.messages.no_routes_found": "Nenhuma rota configurada.",
         "doc.headers.vcn_name": "Nome da VCN",
         "doc.headers.vcn_cidr": "CIDR da VCN",
-        "doc.headers.subnet_name": "Nome da Subnet",
         "doc.headers.subnet_cidr": "CIDR da Subnet",
         "doc.headers.destination_cidr": "CIDR de Destino",
         "doc.headers.common_name": "COMMON NAME",
@@ -514,7 +512,6 @@ DOC_STRINGS = {
         "doc.messages.no_routes_found": "No routes configured.",
         "doc.headers.vcn_name": "VCN Name",
         "doc.headers.vcn_cidr": "VCN CIDR",
-        "doc.headers.subnet_name": "Subnet Name",
         "doc.headers.subnet_cidr": "Subnet CIDR",
         "doc.headers.destination_cidr": "Destination CIDR",
         "doc.headers.common_name": "COMMON NAME",
@@ -2061,13 +2058,16 @@ def generate_documentation(
         for data in infra_data.instances:
             for sl in data.security_lists:
                 entry = sl_map.setdefault(sl.name, {"rules": sl.rules, "hosts": []})
-                if data.host_name not in entry["hosts"]: entry["hosts"].append(data.host_name)
+                if data.host_name not in entry["hosts"]:
+                    entry["hosts"].append(data.host_name)
             for nsg in data.network_security_groups:
                 entry = nsg_map.setdefault(nsg.name, {"rules": nsg.rules, "hosts": []})
-                if data.host_name not in entry["hosts"]: entry["hosts"].append(data.host_name)
+                if data.host_name not in entry["hosts"]:
+                    entry["hosts"].append(data.host_name)
             if data.route_table:
                 entry = rt_map.setdefault(data.route_table.name, {"rules": data.route_table.rules, "hosts": []})
-                if data.host_name not in entry["hosts"]: entry["hosts"].append(data.host_name)
+                if data.host_name not in entry["hosts"]:
+                    entry["hosts"].append(data.host_name)
 
         _add_and_bookmark_heading(document, t("doc.headings.security_lists", lang), 3, headings_for_toc, numbering_counters)
         for name, info in sorted(sl_map.items()):
@@ -2355,8 +2355,8 @@ def _render_single_load_balancer(
         certs_list   = list(getattr(infra_data, "certificates", []) or [])
         cert_id_map  = {c.get("id"): c.get("name") for c in certs_list if isinstance(c, dict) and c.get("id")}
         has_ssl      = any(
-            (getattr(l, "ssl_certificate_ids", None) or [])
-            for l in lb.listeners
+            (getattr(listener, "ssl_certificate_ids", None) or [])
+            for listener in lb.listeners
         )
 
         headers = [

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ from celery_worker import (
     collect_new_host_task,
     collect_waf_report_task,
 )
-from schemas import GenerateDocRequest, TaskCreationResponse, TaskStatusResponse, LetterheadMeta
+from schemas import GenerateDocRequest, TaskCreationResponse, TaskStatusResponse
 
 logging.basicConfig(level=logging.INFO)
 
@@ -684,11 +684,14 @@ async def create_document(
             footer_bytes: Optional[bytes] = None
             cover_bytes:  Optional[bytes] = None
             if lh_meta.enabled and lh_meta.header_file_count == 1 and cursor < len(all_bytes):
-                header_bytes = all_bytes[cursor]; cursor += 1
+                header_bytes = all_bytes[cursor]
+                cursor += 1
             if lh_meta.enabled and lh_meta.footer_file_count == 1 and cursor < len(all_bytes):
-                footer_bytes = all_bytes[cursor]; cursor += 1
+                footer_bytes = all_bytes[cursor]
+                cursor += 1
             if lh_meta.cover_image_file_count == 1 and cursor < len(all_bytes):
-                cover_bytes = all_bytes[cursor]; cursor += 1
+                cover_bytes = all_bytes[cursor]
+                cursor += 1
             resolved_letterhead = {
                 "enabled": lh_meta.enabled,
                 "header":  header_bytes,

--- a/backend/oci_connector.py
+++ b/backend/oci_connector.py
@@ -181,7 +181,8 @@ def _auth_from_profile(profile: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     if profile.get("auth_method", "").upper() == "INSTANCE_PRINCIPAL":
         return get_auth_provider()  # always re-fetches instance principal signer
     try:
-        import tempfile, os as _os
+        import tempfile
+        import os as _os
         key_pem = profile.get("private_key_pem") or ""
         # Write private key to a temp file (OCI SDK requires a file path)
         tf = tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False)

--- a/backend/oci_connector.py
+++ b/backend/oci_connector.py
@@ -182,7 +182,6 @@ def _auth_from_profile(profile: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         return get_auth_provider()  # always re-fetches instance principal signer
     try:
         import tempfile
-        import os as _os
         key_pem = profile.get("private_key_pem") or ""
         # Write private key to a temp file (OCI SDK requires a file path)
         tf = tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False)
@@ -784,7 +783,8 @@ def _get_compartment_certificates(certs_mgmt_client, compartment_id: str) -> lis
             def _dk(d, *keys):
                 for k in keys:
                     v = d.get(k)
-                    if v: return v
+                    if v:
+                        return v
                 return "N/A"
             return {
                 "common_name":            _dk(subj_obj, "common_name",            "common-name"),
@@ -808,7 +808,8 @@ def _get_compartment_certificates(certs_mgmt_client, compartment_id: str) -> lis
             def _dk(d, *keys):
                 for k in keys:
                     v = d.get(k)
-                    if v is not None: return v
+                    if v is not None:
+                        return v
                 return None
             val_d = _dk(cvs_obj, "validity") or {}
             if isinstance(val_d, dict):
@@ -863,7 +864,8 @@ def _get_compartment_certificates(certs_mgmt_client, compartment_id: str) -> lis
             def _dk(d, *keys):
                 for k in keys:
                     v = d.get(k)
-                    if v: return v
+                    if v:
+                        return v
                 return "N/A"
             res_id = _dk(assoc_obj, "associated_resource_id", "associated-resource-id")
         else:
@@ -1374,14 +1376,14 @@ def get_infrastructure_details(
 
         lpgs = [
             LpgData(
-                id=l.id, display_name=l.display_name, lifecycle_state=l.lifecycle_state,
-                peering_status=l.peering_status, peering_status_details=l.peering_status_details,
-                peer_id=l.peer_id, route_table_id=l.route_table_id,
-                peer_advertised_cidr=l.peer_advertised_cidr,
-                is_cross_tenancy_peering=l.is_cross_tenancy_peering,
-                route_table_name=route_table_map.get(l.route_table_id, "N/A"),
+                id=lpg.id, display_name=lpg.display_name, lifecycle_state=lpg.lifecycle_state,
+                peering_status=lpg.peering_status, peering_status_details=lpg.peering_status_details,
+                peer_id=lpg.peer_id, route_table_id=lpg.route_table_id,
+                peer_advertised_cidr=lpg.peer_advertised_cidr,
+                is_cross_tenancy_peering=lpg.is_cross_tenancy_peering,
+                route_table_name=route_table_map.get(lpg.route_table_id, "N/A"),
             )
-            for l in oci.pagination.list_call_get_all_results(
+            for lpg in oci.pagination.list_call_get_all_results(
                 virtual_network_client.list_local_peering_gateways,
                 compartment_id=compartment_id, vcn_id=vcn_sdk.id, retry_strategy=retry_strategy,
             ).data
@@ -1441,15 +1443,15 @@ def get_infrastructure_details(
                     if getattr(l, "ssl_configuration", None) is not None
                     else l.protocol
                 ),
-                port=l.port,
-                default_backend_set_name=l.default_backend_set_name,
-                hostname_names=l.hostname_names if l.hostname_names else [],
+                port=listener.port,
+                default_backend_set_name=listener.default_backend_set_name,
+                hostname_names=listener.hostname_names if listener.hostname_names else [],
                 ssl_certificate_ids=(
-                    list(getattr(l.ssl_configuration, "certificate_ids", None) or [])
-                    if getattr(l, "ssl_configuration", None) is not None else []
+                    list(getattr(listener.ssl_configuration, "certificate_ids", None) or [])
+                    if getattr(listener, "ssl_configuration", None) is not None else []
                 ),
             )
-            for l in lb_details.listeners.values()
+            for listener in lb_details.listeners.values()
         ]
         backend_sets = []
         for bs_sdk in lb_details.backend_sets.values():
@@ -1811,15 +1813,15 @@ def get_waf_report_details(
                                     if getattr(l, "ssl_configuration", None) is not None
                                     else l.protocol
                                 ),
-                                port=l.port,
-                                default_backend_set_name=l.default_backend_set_name,
-                                hostname_names=l.hostname_names if l.hostname_names else [],
+                                port=listener.port,
+                                default_backend_set_name=listener.default_backend_set_name,
+                                hostname_names=listener.hostname_names if listener.hostname_names else [],
                                 ssl_certificate_ids=(
-                                    list(getattr(l.ssl_configuration, "certificate_ids", None) or [])
-                                    if getattr(l, "ssl_configuration", None) is not None else []
+                                    list(getattr(listener.ssl_configuration, "certificate_ids", None) or [])
+                                    if getattr(listener, "ssl_configuration", None) is not None else []
                                 ),
                             )
-                            for l in lb_details.listeners.values()
+                            for listener in lb_details.listeners.values()
                         ]
                         backend_sets = []
                         for bs_sdk in lb_details.backend_sets.values():

--- a/backend/oci_connector.py
+++ b/backend/oci_connector.py
@@ -1437,11 +1437,11 @@ def get_infrastructure_details(
         hostnames = [HostnameData(name=h.name) for h in lb_details.hostnames.values()]
         listeners = [
             ListenerData(
-                name=l.name,
+                name=listener.name,
                 protocol=(
                     "HTTPS"
-                    if getattr(l, "ssl_configuration", None) is not None
-                    else l.protocol
+                    if getattr(listener, "ssl_configuration", None) is not None
+                    else listener.protocol
                 ),
                 port=listener.port,
                 default_backend_set_name=listener.default_backend_set_name,
@@ -1807,11 +1807,11 @@ def get_waf_report_details(
                         hostnames = [HostnameData(name=h.name) for h in lb_details.hostnames.values()]
                         listeners = [
                             ListenerData(
-                                name=l.name,
+                                name=listener.name,
                                 protocol=(
                                     "HTTPS"
-                                    if getattr(l, "ssl_configuration", None) is not None
-                                    else l.protocol
+                                    if getattr(listener, "ssl_configuration", None) is not None
+                                    else listener.protocol
                                 ),
                                 port=listener.port,
                                 default_backend_set_name=listener.default_backend_set_name,


### PR DESCRIPTION
## Summary

- `auth.py`: split compound semicolon statements onto separate lines (E702)
- `doc_generator.py`: remove unused `import docx` (F401), remove duplicate dict keys `doc.headers.subnet_name` in PT/EN dicts (F601), expand inline if-statements (E701), rename ambiguous `l` to `listener` (E741)
- `main.py`: remove unused `LetterheadMeta` import (F401), split cursor increment semicolons (E702)
- `oci_connector.py`: split `import tempfile, os as _os` into two imports (E401)

## Test plan

- [x] CI/Ruff check passes
- [x] Security scans pass (Bandit, pip-audit, Gitleaks)
- [x] Application behaviour unchanged (lint-only fixes)